### PR TITLE
fixed typo:  maxent should be maxnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,14 @@ To run the application, please follow these steps:
 * Restart R session (or restart RStudio)
 
 4. Open NimbleMiner.R in RStudio and run it by the button "Run App"
+
+
+**NB:**  The \"installer.R\" script referenced above installs CRAN dependencies before using devtools to install dependencies maintained on GitHub.  To address dependencies manually or with an external package manager, be advised that NimbleMiner has these CRAN package dependies:
+
+c("shiny", "stringi", "data.table", "DT", "shinythemes", "ggplot2", "keras", "readr", "shinyTree", "shinyjs", "tm", "xtable", "tau", "stopwords", "caret","fs", "devtools", "RTextTools")
+
+These dependencies are from GitHub. Install using devtools.
+
++ [wordVectors](https://github.com/bmschmidt/wordVectors)
++ [rword2vec](https://github.com/mukul13/rword2vec)
++ [maxnet](https://github.com/mrmaxent/maxnet) *is the R implementation of the [MaxEnt](https://biodiversityinformatics.amnh.org/open_source/maxent/) maximum entropy modeling application.  Be careful with your spelling.* 

--- a/installer/installer.R
+++ b/installer/installer.R
@@ -20,6 +20,6 @@ install(paste0(packages_dir,"/wordVectors/wordVectors"))
 
 unzip(paste0(packages_dir,"/rword2vec.zip"),exdir=paste0(packages_dir,"/rword2vec"))
 install(paste0(packages_dir,"/rword2vec/rword2vec"))
-install.packages(paste0(packages_dir,"/maxent.tar.gz"), repos = NULL, type="source")
+install.packages(paste0(packages_dir,"/maxnet.tar.gz"), repos = NULL, type="source")
 install.packages(paste0(packages_dir,"/RTextTools.tar.gz"), repos = NULL, type="source")
 install.packages(paste0(packages_dir,"/NimbleMiner_0.1.0.tar.gz"), repos = NULL, type="source")


### PR DESCRIPTION
There was a typo in the installer script.  The R package maxnet was entered as maxent.  Maxent is a stand-alone Java application for modelling species geographic distributions, so that this is a typo is not immediately obvious.  

FYI:  https://github.com/mrmaxent/Maxent